### PR TITLE
Fix .about.yml; remove vestigal config vars

### DIFF
--- a/.about.yml
+++ b/.about.yml
@@ -2,7 +2,7 @@
 name: edu
 full_name: 18F Edu
 description: |
-18F Edu is the self-guided training component of the 18F Learn initiative. It aims to supplement the 18F Guides with hands-on exercises that can solidify your grasp of those materials. The combined body of 18F Guides and 18F Edu training modules aim to support the concepts promoted in the U.S. Digital Services Playbook.
+  18F Edu is the self-guided training component of the 18F Learn initiative. It aims to supplement the 18F Guides with hands-on exercises that can solidify your grasp of those materials. The combined body of 18F Guides and 18F Edu training modules aim to support the concepts promoted in the U.S. Digital Services Playbook.
 type: docs
 owner_type: project
 status: active

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,3 @@
-baseurl: /edu
 markdown: redcarpet
 name: 18F Edu [DRAFT]
 exclude:
@@ -10,10 +9,6 @@ exclude:
 
 permalink: pretty
 highlighter: rouge
-
-# To use the shared 18F Guides styles when deploying to pages.18f.gov,
-# uncomment the following:
-asset_root: /guides-template
 
 # Author/Organization info to be displayed in the templates
 author:


### PR DESCRIPTION
Fixes the `.about.yml` parse error noticed in #4, and also removes vestigal config vars per 18F/pages#22.

@wslack would you like to do the honors?
